### PR TITLE
Building using MinGW C++ Compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,11 @@ project (Galaxy)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if (WIN32)
+  include_directories(win)  
+endif()
+
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  include_directories(win)
   add_compile_definitions(_USE_MATH_DEFINES)
 endif()
 


### PR DESCRIPTION
Added support for building the project using MinGW C++ compiler on Windows Platform.
If on Windows platform, always include `win` directory.